### PR TITLE
change slack auto update key

### DIFF
--- a/Slack (com.tinyspec.slackmacgap).json
+++ b/Slack (com.tinyspec.slackmacgap).json
@@ -1,18 +1,18 @@
 {
     "title": "Slack (com.tinyspec.slackmacgap)",
-    "description": "Manage Slack settings. https://slack.com/help/articles/360035635174-Deploy-Slack-for-macOS",
+    "description": "Manage Slack settings. https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations#mac-2",
     "__feedback": "bill@talkingmoose.net",
     "properties": {
-        "SlackNoAutoUpdates": {
+        "AutoUpdate": {
             "title": "Automatic Updates",
             "description": "Turn automatic updates on or off. Requires version 4.0 or later.",
             "property_order": 5,
             "type": "string",
             "options": {
-                "enum_titles": ["On", "Off"]
+                "enum_titles": ["Off", "On"]
             },
             "enum": ["0","1"]
         }
     },
-    "required": ["SlackNoAutoUpdates"]
+    "required": ["AutoUpdate"]
 }


### PR DESCRIPTION
Slack changed the key associated with auto updates, PR is to update the schema to reflect that change.

Slack deprecation documentation (announcement date 4/22/24): https://slack.com/help/articles/4426294050451-Slack-feature-retirements#retired-features

Slack documentation referencing the new key: https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations#mac-2

(wasn't sure where best to submit this PR, to this repo or https://github.com/Jamf-Custom-Profile-Schemas/jamf-manifests, so I did both 😉)